### PR TITLE
Add missing type to build-administrator-role-relationships step

### DIFF
--- a/src/steps/build-administrator-role-relationships/index.ts
+++ b/src/steps/build-administrator-role-relationships/index.ts
@@ -13,7 +13,7 @@ import { STEP_ID as ROLE_STEP, ROLE_TYPE } from '../fetch-administrator-roles';
 const step: IntegrationStep = {
   id: 'build-administrator-role-relationships',
   name: 'Build administrator role relationships',
-  types: [],
+  types: ['trend_micro_administrator_assigned_role'],
   dependsOn: [ADMIN_STEP, ROLE_STEP],
   async executionHandler({ jobState }: IntegrationStepExecutionContext) {
     const roleIdMap = await createRoleIdMap(jobState);


### PR DESCRIPTION
oops forgot about this. It's pretty easy to get a relationship's type by just building it and seeing what happens, but it might be helpful to add documentation on how types are generated.