### PR TITLE
Convert id to camelcase + standardize on format of _key and id properties

### DIFF
--- a/src/steps/build-administrator-role-relationships/__tests__/__fixtures__/entities.json
+++ b/src/steps/build-administrator-role-relationships/__tests__/__fixtures__/entities.json
@@ -8,7 +8,7 @@
     "_class": [
       "User"
     ],
-    "roleID": 1,
+    "roleId": "1",
     "name": "charlie.duong@jupiterone.io",
     "createdOn": 1586982455921,
     "displayName": "charlie.duong@jupiterone.io"
@@ -22,7 +22,7 @@
     "_class": [
       "User"
     ],
-    "roleID": 2,
+    "roleId": "2",
     "name": "Charlie Test",
     "createdOn": 1587489647292,
     "displayName": "Charlie Test"
@@ -36,7 +36,7 @@
     "_class": [
       "AccessRole"
     ],
-    "ID": 1,
+    "id": "1",
     "displayName": "Full Access"
   },
   {
@@ -47,7 +47,7 @@
     "_class": [
       "AccessRole"
     ],
-    "ID": 2,
+    "id": "2",
     "displayName": "Auditor"
   },
   {
@@ -58,7 +58,7 @@
     "_class": [
       "AccessRole"
     ],
-    "ID": 3,
+    "id": "3",
     "displayName": "New Role"
   },
   {
@@ -69,7 +69,7 @@
     "_class": [
       "AccessRole"
     ],
-    "ID": 4,
+    "id": "4",
     "displayName": "New Role_2"
   }
 ]

--- a/src/steps/build-administrator-role-relationships/__tests__/__fixtures__/entities.json
+++ b/src/steps/build-administrator-role-relationships/__tests__/__fixtures__/entities.json
@@ -8,7 +8,7 @@
     "_class": [
       "User"
     ],
-    "roleId": "1",
+    "roleId": "trend-micro-administrator-role:1",
     "name": "charlie.duong@jupiterone.io",
     "createdOn": 1586982455921,
     "displayName": "charlie.duong@jupiterone.io"
@@ -22,7 +22,7 @@
     "_class": [
       "User"
     ],
-    "roleId": "2",
+    "roleId": "trend-micro-administrator-role:2",
     "name": "Charlie Test",
     "createdOn": 1587489647292,
     "displayName": "Charlie Test"
@@ -31,45 +31,49 @@
   {
     "name": "Full Access",
     "description": "",
-    "_key": "urn:tmds:identity:us-east-ds-1:78422:role/Full Access",
+    "_key": "trend-micro-administrator-role:1",
     "_type": "trend_micro_administrator_role",
     "_class": [
       "AccessRole"
     ],
-    "id": "1",
+    "urn": "urn:tmds:identity:us-east-ds-1:78422:role/Full Access",
+    "id": "trend-micro-administrator-role:1",
     "displayName": "Full Access"
   },
   {
     "name": "Auditor",
     "description": "",
-    "_key": "urn:tmds:identity:us-east-ds-1:78422:role/Auditor",
+    "_key": "trend-micro-administrator-role:2",
     "_type": "trend_micro_administrator_role",
     "_class": [
       "AccessRole"
     ],
-    "id": "2",
+    "urn": "urn:tmds:identity:us-east-ds-1:78422:role/Auditor",
+    "id": "trend-micro-administrator-role:2",
     "displayName": "Auditor"
   },
   {
     "name": "New Role",
     "description": "",
-    "_key": "urn:tmds:identity:us-east-ds-1:78422:role/New Role",
+    "_key": "trend-micro-administrator-role:3",
     "_type": "trend_micro_administrator_role",
     "_class": [
       "AccessRole"
     ],
-    "id": "3",
+    "urn": "urn:tmds:identity:us-east-ds-1:78422:role/New Role",
+    "id": "trend-micro-administrator-role:3",
     "displayName": "New Role"
   },
   {
     "name": "New Role_2",
     "description": "",
-    "_key": "urn:tmds:identity:us-east-ds-1:78422:role/New Role_2",
+    "_key": "trend-micro-administrator-role:4",
     "_type": "trend_micro_administrator_role",
     "_class": [
       "AccessRole"
     ],
-    "id": "4",
+    "urn": "urn:tmds:identity:us-east-ds-1:78422:role/New Role_2",
+    "id": "trend-micro-administrator-role:4",
     "displayName": "New Role_2"
   }
 ]

--- a/src/steps/build-administrator-role-relationships/__tests__/index.test.ts
+++ b/src/steps/build-administrator-role-relationships/__tests__/index.test.ts
@@ -14,19 +14,19 @@ test('step data collection', async () => {
   expect(context.jobState.collectedRelationships).toEqual([
     expect.objectContaining({
       _key:
-        'trend-micro-administrator:1|assigned|urn:tmds:identity:us-east-ds-1:78422:role/Full Access',
+        'trend-micro-administrator:1|assigned|trend-micro-administrator-role:1',
       _type: 'trend_micro_administrator_assigned_role',
       _class: 'ASSIGNED',
       _fromEntityKey: 'trend-micro-administrator:1',
-      _toEntityKey: 'urn:tmds:identity:us-east-ds-1:78422:role/Full Access',
+      _toEntityKey: 'trend-micro-administrator-role:1',
     }),
     expect.objectContaining({
       _key:
-        'trend-micro-administrator:8|assigned|urn:tmds:identity:us-east-ds-1:78422:role/Auditor',
+        'trend-micro-administrator:8|assigned|trend-micro-administrator-role:2',
       _type: 'trend_micro_administrator_assigned_role',
       _class: 'ASSIGNED',
       _fromEntityKey: 'trend-micro-administrator:8',
-      _toEntityKey: 'urn:tmds:identity:us-east-ds-1:78422:role/Auditor',
+      _toEntityKey: 'trend-micro-administrator-role:2',
     }),
   ]);
 });

--- a/src/steps/build-administrator-role-relationships/index.ts
+++ b/src/steps/build-administrator-role-relationships/index.ts
@@ -19,7 +19,7 @@ const step: IntegrationStep = {
     const roleIdMap = await createRoleIdMap(jobState);
 
     await jobState.iterateEntities({ _type: ADMIN_TYPE }, async (admin) => {
-      const role = roleIdMap.get(admin.roleID as number);
+      const role = roleIdMap.get(admin.roleId as string);
 
       if (role) {
         const relationship = createAdministratorToRoleRelationship(admin, role);
@@ -31,11 +31,11 @@ const step: IntegrationStep = {
 
 async function createRoleIdMap(
   jobState: JobState,
-): Promise<Map<number, Entity>> {
-  const roleIdMap = new Map<number, Entity>();
+): Promise<Map<string, Entity>> {
+  const roleIdMap = new Map<string, Entity>();
   await jobState.iterateEntities({ _type: ROLE_TYPE }, (role) => {
     // unfortunately need to cast because of EntityPropertyValue type
-    roleIdMap.set(role.ID as number, role);
+    roleIdMap.set(role.id as string, role);
   });
   return roleIdMap;
 }

--- a/src/steps/build-computer-group-relationships/__tests__/__fixtures__/entities.json
+++ b/src/steps/build-computer-group-relationships/__tests__/__fixtures__/entities.json
@@ -8,7 +8,7 @@
     "_class": ["Host"],
     "name": "ec2-54-187-35-33.us-west-2.compute.amazonaws.com",
     "hostname": "ec2-54-187-35-33.us-west-2.compute.amazonaws.com",
-    "groupID": 0
+    "groupId": "0"
   },
   {
     "displayName": "i-075776bd5b0b322aa",
@@ -19,7 +19,7 @@
     "_class": ["Host"],
     "name": "i-075776bd5b0b322aa",
     "hostname": "172.31.121.120",
-    "groupID": 79
+    "groupId": "79"
   },
   {
     "displayName": "i-0dca1d41741a0a411",
@@ -30,7 +30,7 @@
     "_class": ["Host"],
     "name": "i-0dca1d41741a0a411",
     "hostname": "172.31.211.111",
-    "groupID": 79
+    "groupId": "79"
   },
   {
     "name": "cduong - 697977203433",
@@ -38,7 +38,7 @@
     "_type": "trend_micro_computer_group",
     "_class": ["Group"],
     "type": "aws-account",
-    "ID": 1,
+    "id": "1",
     "displayName": "cduong - 697977203433"
   },
   {
@@ -46,10 +46,10 @@
     "_key": "trend-micro-computer-group:2",
     "_type": "trend_micro_computer_group",
     "_class": ["Group"],
-    "parentGroupID": 1,
+    "parentGroupId": "1",
     "cloudType": "amazon",
     "type": "aws-region",
-    "ID": "2",
+    "id": "2",
     "displayName": "EU (Stockholm)"
   },
   {
@@ -57,11 +57,11 @@
     "_key": "trend-micro-computer-group:78",
     "_type": "trend_micro_computer_group",
     "_class": ["Group"],
-    "parentGroupID": 74,
+    "parentGroupId": "74",
     "cloudType": "amazon",
-    "amazonSubnetID": 45,
+    "amazonSubnetId": "45",
     "type": "aws-subnet",
-    "ID": 78,
+    "id": "78",
     "displayName": "subnet-c6ae24b1"
   },
   {
@@ -69,11 +69,11 @@
     "_key": "trend-micro-computer-group:79",
     "_type": "trend_micro_computer_group",
     "_class": ["Group"],
-    "parentGroupID": 66,
+    "parentGroupId": "66",
     "cloudType": "amazon",
-    "amazonSubnetID": 46,
+    "amazonSubnetId": "46",
     "type": "aws-subnet",
-    "ID": 79,
+    "id": "79",
     "displayName": "deepsecurity (subnet-09eb438f49fbf5900)"
   }
 ]

--- a/src/steps/build-computer-group-relationships/__tests__/__fixtures__/entities.json
+++ b/src/steps/build-computer-group-relationships/__tests__/__fixtures__/entities.json
@@ -8,7 +8,7 @@
     "_class": ["Host"],
     "name": "ec2-54-187-35-33.us-west-2.compute.amazonaws.com",
     "hostname": "ec2-54-187-35-33.us-west-2.compute.amazonaws.com",
-    "groupId": "0"
+    "groupId": "trend-micro-computer-group:0"
   },
   {
     "displayName": "i-075776bd5b0b322aa",
@@ -19,7 +19,7 @@
     "_class": ["Host"],
     "name": "i-075776bd5b0b322aa",
     "hostname": "172.31.121.120",
-    "groupId": "79"
+    "groupId": "trend-micro-computer-group:79"
   },
   {
     "displayName": "i-0dca1d41741a0a411",
@@ -30,7 +30,7 @@
     "_class": ["Host"],
     "name": "i-0dca1d41741a0a411",
     "hostname": "172.31.211.111",
-    "groupId": "79"
+    "groupId": "trend-micro-computer-group:79"
   },
   {
     "name": "cduong - 697977203433",
@@ -38,7 +38,7 @@
     "_type": "trend_micro_computer_group",
     "_class": ["Group"],
     "type": "aws-account",
-    "id": "1",
+    "id": "trend-micro-computer-group:1",
     "displayName": "cduong - 697977203433"
   },
   {
@@ -49,7 +49,7 @@
     "parentGroupId": "1",
     "cloudType": "amazon",
     "type": "aws-region",
-    "id": "2",
+    "id": "trend-micro-computer-group:2",
     "displayName": "EU (Stockholm)"
   },
   {
@@ -61,7 +61,7 @@
     "cloudType": "amazon",
     "amazonSubnetId": "45",
     "type": "aws-subnet",
-    "id": "78",
+    "id": "trend-micro-computer-group:78",
     "displayName": "subnet-c6ae24b1"
   },
   {
@@ -73,7 +73,7 @@
     "cloudType": "amazon",
     "amazonSubnetId": "46",
     "type": "aws-subnet",
-    "id": "79",
+    "id": "trend-micro-computer-group:79",
     "displayName": "deepsecurity (subnet-09eb438f49fbf5900)"
   }
 ]

--- a/src/steps/build-computer-group-relationships/index.ts
+++ b/src/steps/build-computer-group-relationships/index.ts
@@ -24,7 +24,7 @@ const step: IntegrationStep = {
     await jobState.iterateEntities(
       { _type: COMPUTER_TYPE },
       async (computer) => {
-        const group = groupIdMap.get(computer.groupID as number);
+        const group = groupIdMap.get(computer.groupId as string);
 
         if (group) {
           const relationship = createComputerGroupRelationship(computer, group);
@@ -37,11 +37,11 @@ const step: IntegrationStep = {
 
 async function createComputerGroupIdMap(
   jobState: JobState,
-): Promise<Map<number, Entity>> {
-  const groupIdMap = new Map<number, Entity>();
+): Promise<Map<string, Entity>> {
+  const groupIdMap = new Map<string, Entity>();
   await jobState.iterateEntities({ _type: COMPUTER_GROUP_TYPE }, (group) => {
     // unfortunately need to cast because of EntityPropertyValue type
-    groupIdMap.set(group.ID as number, group);
+    groupIdMap.set(group.id as string, group);
   });
   return groupIdMap;
 }

--- a/src/steps/fetch-administrator-roles/__tests__/index.test.ts
+++ b/src/steps/fetch-administrator-roles/__tests__/index.test.ts
@@ -41,6 +41,7 @@ test('administratorRole fetching', async () => {
         allPolicies: true,
         allowUserInterface: true,
         allowWebService: true,
+        ID: 1,
       }),
       expect.objectContaining({
         name: 'Auditor',
@@ -52,6 +53,7 @@ test('administratorRole fetching', async () => {
         allPolicies: true,
         allowUserInterface: true,
         allowWebService: true,
+        ID: 2,
       }),
       expect.objectContaining({
         name: 'New Role',
@@ -63,6 +65,7 @@ test('administratorRole fetching', async () => {
         allPolicies: true,
         allowUserInterface: true,
         allowWebService: false,
+        ID: 3,
       }),
       expect.objectContaining({
         name: 'New Role_2',
@@ -74,12 +77,13 @@ test('administratorRole fetching', async () => {
         allPolicies: true,
         allowUserInterface: true,
         allowWebService: false,
+        ID: 4,
       }),
     ]),
   });
 });
 
-test('administator entity conversion', async () => {
+test('administator role entity conversion', async () => {
   const role = {
     ID: 4,
     name: 'New Role_2',
@@ -95,9 +99,10 @@ test('administator entity conversion', async () => {
 
   expect(createAdministratorRoleEntity(role)).toEqual({
     name: 'New Role_2',
-    id: '4',
+    id: 'trend-micro-administrator-role:4',
     description: '',
-    _key: 'urn:tmds:identity:us-east-ds-1:78422:role/New Role_2',
+    urn: 'urn:tmds:identity:us-east-ds-1:78422:role/New Role_2',
+    _key: 'trend-micro-administrator-role:4',
     _type: 'trend_micro_administrator_role',
     _class: ['AccessRole'],
     createdOn: undefined,
@@ -115,16 +120,16 @@ test('step data collection', async () => {
 
   expect(context.jobState.collectedEntities).toEqual([
     expect.objectContaining({
-      _key: 'urn:tmds:identity:us-east-ds-1:78422:role/Full Access',
+      _key: 'trend-micro-administrator-role:1',
     }),
     expect.objectContaining({
-      _key: 'urn:tmds:identity:us-east-ds-1:78422:role/Auditor',
+      _key: 'trend-micro-administrator-role:2',
     }),
     expect.objectContaining({
-      _key: 'urn:tmds:identity:us-east-ds-1:78422:role/New Role',
+      _key: 'trend-micro-administrator-role:3',
     }),
     expect.objectContaining({
-      _key: 'urn:tmds:identity:us-east-ds-1:78422:role/New Role_2',
+      _key: 'trend-micro-administrator-role:4',
     }),
   ]);
 });

--- a/src/steps/fetch-administrator-roles/__tests__/index.test.ts
+++ b/src/steps/fetch-administrator-roles/__tests__/index.test.ts
@@ -95,7 +95,7 @@ test('administator entity conversion', async () => {
 
   expect(createAdministratorRoleEntity(role)).toEqual({
     name: 'New Role_2',
-    ID: 4,
+    id: '4',
     description: '',
     _key: 'urn:tmds:identity:us-east-ds-1:78422:role/New Role_2',
     _type: 'trend_micro_administrator_role',

--- a/src/steps/fetch-administrator-roles/index.ts
+++ b/src/steps/fetch-administrator-roles/index.ts
@@ -41,7 +41,7 @@ export function createAdministratorRoleEntity(
         _key: role.urn,
         _type: ROLE_TYPE,
         _class: 'AccessRole',
-        ID: role.ID,
+        id: role.ID.toString(), // must cast to string to match data model
         // normalize property names to match data model
         name: role.name || role.urn,
       },

--- a/src/steps/fetch-administrator-roles/index.ts
+++ b/src/steps/fetch-administrator-roles/index.ts
@@ -34,17 +34,29 @@ export default step;
 export function createAdministratorRoleEntity(
   role: DeepSecurityAdministratorRole,
 ): Entity {
+  const id = createAdministratorRoleEntityIdentifier(role.ID);
   return createIntegrationEntity({
     entityData: {
       source: role,
       assign: {
-        _key: role.urn,
+        _key: id,
         _type: ROLE_TYPE,
         _class: 'AccessRole',
-        id: role.ID.toString(), // must cast to string to match data model
+        id,
+        urn: role.urn,
         // normalize property names to match data model
         name: role.name || role.urn,
       },
     },
   });
+}
+
+/**
+ * DO NOT change this constant. IDs are not long enough
+ * to generate keys that match the min length
+ * the data model requires
+ */
+const ADMIN_ROLE_ID_PREFIX = 'trend-micro-administrator-role';
+export function createAdministratorRoleEntityIdentifier(id: number): string {
+  return `${ADMIN_ROLE_ID_PREFIX}:${id}`;
 }

--- a/src/steps/fetch-administrators/__tests__/index.test.ts
+++ b/src/steps/fetch-administrators/__tests__/index.test.ts
@@ -130,7 +130,7 @@ test('administator entity conversion', async () => {
     name: 'Charlie Test',
     createdOn: 1587489647292,
     username: 'charlie.duong.test',
-    roleID: 2,
+    roleId: 2,
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-administrators/index.ts
+++ b/src/steps/fetch-administrators/index.ts
@@ -38,7 +38,7 @@ export function createAdministratorEntity(
     entityData: {
       source: administrator,
       assign: {
-        _key: createAdministratorEntityIdentifier(administrator),
+        _key: createAdministratorEntityIdentifier(administrator.ID),
         _type: ADMIN_TYPE,
         _class: 'User',
 
@@ -57,8 +57,6 @@ export function createAdministratorEntity(
  * the data model requires
  */
 const ADMIN_ID_PREFIX = 'trend-micro-administrator';
-function createAdministratorEntityIdentifier(
-  administrator: DeepSecurityAdministrator,
-): string {
-  return `${ADMIN_ID_PREFIX}:${administrator.ID}`;
+function createAdministratorEntityIdentifier(id: string): string {
+  return `${ADMIN_ID_PREFIX}:${id}`;
 }

--- a/src/steps/fetch-administrators/index.ts
+++ b/src/steps/fetch-administrators/index.ts
@@ -42,7 +42,7 @@ export function createAdministratorEntity(
         _type: ADMIN_TYPE,
         _class: 'User',
 
-        roleID: administrator.roleID,
+        roleId: administrator.roleID,
         // normalize property names to match data model
         name: administrator.fullName || administrator.username,
         createdOn: administrator.created,

--- a/src/steps/fetch-api-keys/__tests__/index.test.ts
+++ b/src/steps/fetch-api-keys/__tests__/index.test.ts
@@ -86,7 +86,7 @@ test('api key entity conversion', async () => {
     _class: ['Key'],
     name: 'jupiterone-test',
     createdOn: 1586982900004,
-    id: '2',
+    id: 'trend-micro-api-key:2',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-api-keys/__tests__/index.test.ts
+++ b/src/steps/fetch-api-keys/__tests__/index.test.ts
@@ -86,6 +86,7 @@ test('api key entity conversion', async () => {
     _class: ['Key'],
     name: 'jupiterone-test',
     createdOn: 1586982900004,
+    id: '2',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-api-keys/index.ts
+++ b/src/steps/fetch-api-keys/index.ts
@@ -39,6 +39,7 @@ export function createApiKeyEntity(apiKey: DeepSecurityApiKey): Entity {
         // normalize property names to match data model
         name: apiKey.keyName,
         createdOn: apiKey.created,
+        id: apiKey.ID.toString(),
       },
     },
   });

--- a/src/steps/fetch-api-keys/index.ts
+++ b/src/steps/fetch-api-keys/index.ts
@@ -28,18 +28,19 @@ const step: IntegrationStep = {
 export default step;
 
 export function createApiKeyEntity(apiKey: DeepSecurityApiKey): Entity {
+  const id = createApiKeyEntityIdentifier(apiKey.ID);
   return createIntegrationEntity({
     entityData: {
       source: apiKey,
       assign: {
-        _key: createApiKeyEntityIdentifier(apiKey),
+        _key: id,
         _type: API_KEY_TYPE,
         _class: 'Key',
 
         // normalize property names to match data model
+        id,
         name: apiKey.keyName,
         createdOn: apiKey.created,
-        id: apiKey.ID.toString(),
       },
     },
   });
@@ -51,6 +52,6 @@ export function createApiKeyEntity(apiKey: DeepSecurityApiKey): Entity {
  * the data model requires
  */
 const API_KEY_ID_PREFIX = 'trend-micro-api-key';
-function createApiKeyEntityIdentifier(apiKey: DeepSecurityApiKey): string {
-  return `${API_KEY_ID_PREFIX}:${apiKey.ID}`;
+function createApiKeyEntityIdentifier(id: string): string {
+  return `${API_KEY_ID_PREFIX}:${id}`;
 }

--- a/src/steps/fetch-computer-groups/__tests__/index.test.ts
+++ b/src/steps/fetch-computer-groups/__tests__/index.test.ts
@@ -75,11 +75,11 @@ test('computer entity conversion', async () => {
     _class: ['Group'],
     type: 'aws-subnet',
     cloudType: 'amazon',
-    parentGroupId: '74',
-    amazonSubnetId: '43',
+    parentGroupId: 'trend-micro-computer-group:74',
+    amazonSubnetId: 'trend-micro-computer-group:43',
     name: 'subnet-ed0c7888',
     displayName: 'subnet-ed0c7888',
-    id: '76',
+    id: 'trend-micro-computer-group:76',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-computer-groups/__tests__/index.test.ts
+++ b/src/steps/fetch-computer-groups/__tests__/index.test.ts
@@ -75,11 +75,11 @@ test('computer entity conversion', async () => {
     _class: ['Group'],
     type: 'aws-subnet',
     cloudType: 'amazon',
-    parentGroupID: 74,
-    amazonSubnetID: 43,
+    parentGroupId: '74',
+    amazonSubnetId: '43',
     name: 'subnet-ed0c7888',
     displayName: 'subnet-ed0c7888',
-    ID: 76,
+    id: '76',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-computer-groups/index.ts
+++ b/src/steps/fetch-computer-groups/index.ts
@@ -60,12 +60,10 @@ export function createComputerGroupEntity(
 
         // stringify to match data model
         id,
-        amazonSubnetId: group.amazonSubnetID
-          ? createComputerGroupEntityIdentifier(group.amazonSubnetID)
-          : undefined,
-        parentGroupId: group.parentGroupID
-          ? createComputerGroupEntityIdentifier(group.parentGroupID)
-          : undefined,
+        amazonSubnetId: createComputerGroupEntityIdentifier(
+          group.amazonSubnetID,
+        ),
+        parentGroupId: createComputerGroupEntityIdentifier(group.parentGroupID),
       },
     },
   });
@@ -77,6 +75,6 @@ export function createComputerGroupEntity(
  * the data model requires
  */
 const COMPUTER_GROUP_ID_PREFIX = 'trend-micro-computer-group';
-export function createComputerGroupEntityIdentifier(id: string): string {
-  return `${COMPUTER_GROUP_ID_PREFIX}:${id}`;
+export function createComputerGroupEntityIdentifier(id?: string): string {
+  return id ? `${COMPUTER_GROUP_ID_PREFIX}:${id}` : undefined;
 }

--- a/src/steps/fetch-computer-groups/index.ts
+++ b/src/steps/fetch-computer-groups/index.ts
@@ -53,11 +53,13 @@ export function createComputerGroupEntity(
         // So for now we will consider computerGroups as
         // generic Group entities.
         _class: 'Group',
-        parentGroupID: group.parentGroupID,
         cloudType: group.cloudType,
-        amazonSubnetID: group.amazonSubnetID,
         type: group.type,
-        ID: group.ID,
+
+        // stringify to match data model
+        id: group.ID.toString(),
+        amazonSubnetId: group.amazonSubnetID?.toString?.(),
+        parentGroupId: group.parentGroupID?.toString?.(),
       },
     },
   });

--- a/src/steps/fetch-computer-groups/index.ts
+++ b/src/steps/fetch-computer-groups/index.ts
@@ -34,11 +34,13 @@ export default step;
 export function createComputerGroupEntity(
   group: DeepSecurityComputerGroup,
 ): Entity {
+  const id = createComputerGroupEntityIdentifier(group.ID);
+
   return createIntegrationEntity({
     entityData: {
       source: group,
       assign: {
-        _key: createComputerGroupEntityIdentifier(group),
+        _key: id,
         _type: COMPUTER_GROUP_TYPE,
         // NOTE: Some of the entities collected through this may seem
         // like they really should be part of the Network class
@@ -57,9 +59,13 @@ export function createComputerGroupEntity(
         type: group.type,
 
         // stringify to match data model
-        id: group.ID.toString(),
-        amazonSubnetId: group.amazonSubnetID?.toString?.(),
-        parentGroupId: group.parentGroupID?.toString?.(),
+        id,
+        amazonSubnetId: group.amazonSubnetID
+          ? createComputerGroupEntityIdentifier(group.amazonSubnetID)
+          : undefined,
+        parentGroupId: group.parentGroupID
+          ? createComputerGroupEntityIdentifier(group.parentGroupID)
+          : undefined,
       },
     },
   });
@@ -71,8 +77,6 @@ export function createComputerGroupEntity(
  * the data model requires
  */
 const COMPUTER_GROUP_ID_PREFIX = 'trend-micro-computer-group';
-function createComputerGroupEntityIdentifier(
-  group: DeepSecurityComputerGroup,
-): string {
-  return `${COMPUTER_GROUP_ID_PREFIX}:${group.ID}`;
+export function createComputerGroupEntityIdentifier(id: string): string {
+  return `${COMPUTER_GROUP_ID_PREFIX}:${id}`;
 }

--- a/src/steps/fetch-computers/__tests__/index.test.ts
+++ b/src/steps/fetch-computers/__tests__/index.test.ts
@@ -96,8 +96,8 @@ test('computer entity conversion', async () => {
     displayName: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     hostname: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     platform: 'linux',
-    id: '1',
-    groupId: '25',
+    id: 'trend-micro-computer:1',
+    groupId: 'trend-micro-computer-group:25',
     description:
       "This computer is a demonstration of Deep Security's capabilities. Open a browser to http://ec2-54-187-35-33.us-west-2.compute.amazonaws.com for more information.",
     _rawData: [

--- a/src/steps/fetch-computers/__tests__/index.test.ts
+++ b/src/steps/fetch-computers/__tests__/index.test.ts
@@ -96,7 +96,7 @@ test('computer entity conversion', async () => {
     displayName: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     hostname: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     platform: 'linux',
-    groupID: 25,
+    groupId: '25',
     description:
       "This computer is a demonstration of Deep Security's capabilities. Open a browser to http://ec2-54-187-35-33.us-west-2.compute.amazonaws.com for more information.",
     _rawData: [

--- a/src/steps/fetch-computers/__tests__/index.test.ts
+++ b/src/steps/fetch-computers/__tests__/index.test.ts
@@ -96,6 +96,7 @@ test('computer entity conversion', async () => {
     displayName: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     hostname: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     platform: 'linux',
+    id: '1',
     groupId: '25',
     description:
       "This computer is a demonstration of Deep Security's capabilities. Open a browser to http://ec2-54-187-35-33.us-west-2.compute.amazonaws.com for more information.",

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@jupiterone/integration-sdk';
 
 import { createDeepSecurityClient, DeepSecurityComputer } from '../../provider';
+import { createComputerGroupEntityIdentifier } from '../fetch-computer-groups';
 
 export const STEP_ID = 'fetch-computers';
 export const COMPUTER_TYPE = 'trend_micro_computer';
@@ -29,21 +30,22 @@ const step: IntegrationStep = {
 export default step;
 
 export function createComputerEntity(computer: DeepSecurityComputer): Entity {
+  const id = createComputerEntityIdentifier(computer.ID);
   return createIntegrationEntity({
     entityData: {
       source: computer,
       assign: {
-        _key: createComputerEntityIdentifier(computer),
+        _key: id,
         _type: COMPUTER_TYPE,
         _class: 'Host',
 
         // normalize property names to match data model
+        id,
         createdOn: computer.created,
         name: computer.displayName || computer.hostName,
         hostname: computer.hostName,
         platform: extractPlatform(computer.platform),
-        groupId: computer.groupID.toString(),
-        id: computer.ID.toString(),
+        groupId: createComputerGroupEntityIdentifier(computer.groupID),
       },
     },
   });
@@ -55,10 +57,8 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
  * the data model requires
  */
 const COMPUTER_ID_PREFIX = 'trend-micro-computer';
-function createComputerEntityIdentifier(
-  computer: DeepSecurityComputer,
-): string {
-  return `${COMPUTER_ID_PREFIX}:${computer.ID}`;
+export function createComputerEntityIdentifier(id: string): string {
+  return `${COMPUTER_ID_PREFIX}:${id}`;
 }
 
 /**

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -42,7 +42,7 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
         name: computer.displayName || computer.hostName,
         hostname: computer.hostName,
         platform: extractPlatform(computer.platform),
-        groupID: computer.groupID,
+        groupId: computer.groupID.toString(),
       },
     },
   });

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -43,6 +43,7 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
         hostname: computer.hostName,
         platform: extractPlatform(computer.platform),
         groupId: computer.groupID.toString(),
+        id: computer.ID.toString(),
       },
     },
   });


### PR DESCRIPTION
The `id` of entities are now essentially just the entity `_key` since that's the best way to keep values unique. I did a little refactoring to make the format of `_key` and `id` values more consistent and also made all resources that return an `ID` have an `id` property on the entity.