### PR TITLE
add properties to trend_micro_computer

### DIFF
--- a/src/steps/fetch-computers/__tests__/index.test.ts
+++ b/src/steps/fetch-computers/__tests__/index.test.ts
@@ -105,6 +105,14 @@ test('computer entity conversion', () => {
     groupId: 'trend-micro-computer-group:25',
     description:
       "This computer is a demonstration of Deep Security's capabilities. Open a browser to http://ec2-54-187-35-33.us-west-2.compute.amazonaws.com for more information.",
+    agentGUID: undefined,
+    agentStatus: undefined,
+    applianceStatus: undefined,
+    awsAccountId: undefined,
+    cloudProvider: undefined,
+    createdOn: undefined,
+    ec2InstanceId: undefined,
+    hostGUID: '6BE38408-DA9E-4A03-1EB4-5CE824AD0C58',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -50,6 +50,9 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
         hostname: computer.hostName,
         platform: extractPlatform(computer.platform),
         groupId: createComputerGroupEntityIdentifier(computer.groupID),
+        cloudProvider: computer.ec2VirtualMachineSummary?.cloudProvider,
+        awsAccountId: computer.ec2VirtualMachineSummary?.accountID,
+        ec2InstanceId: computer.ec2VirtualMachineSummary?.instanceID,
       },
     },
   });

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -53,6 +53,10 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
         cloudProvider: computer.ec2VirtualMachineSummary?.cloudProvider,
         awsAccountId: computer.ec2VirtualMachineSummary?.accountID,
         ec2InstanceId: computer.ec2VirtualMachineSummary?.instanceID,
+        agentStatus: computer.computerStatus?.agentStatus,
+        applianceStatus: computer.computerStatus?.applianceStatus,
+        agentGUID: computer.agentGUID,
+        hostGUID: computer.hostGUID,
       },
     },
   });


### PR DESCRIPTION
# Description

This PR adds properties to the `trend_micro_computer` to facilitate mapping to ec2Instances.

Raw example response from Trend Micro for comparison (I removed the parts that weren't relevant):
```json
{
  "computers": [
    {
      "ec2VirtualMachineSummary": {
        "cloudProvider": "string",
        "accountID": "string",
        "operatingSystem": "string",
        "privateIPAddress": "string",
        "publicIPAddress": "string",
        "availabilityZone": "string",
        "instanceID": "string",
        "securityGroups": [
          {
            "name": "string",
            "ID": "string"
          }
        ],
        "type": "string",
        "virtualizationType": "string",
        "state": "string",
        "metadata": [
          {
            "name": "string",
            "value": "string"
          }
        ],
        "DNSName": "string",
        "amiID": "string"
      },
  ]
}
```
