### PR TITLE
INT-5283 - Add Device class to trend_micro_computer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to
 ### Added
 
 - Assigned 'Device' class to the `trend_micro_computer` entity. As of now, the
-  `trend_micro_computer` entitiy is classified as both 'Host' and 'Device'.
+  `trend_micro_computer` entity is classified as both 'Host' and 'Device'.
 
 ## 2.2.4 - 2022-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Assigned 'Device' class to the `trend_micro_computer` entity. As of now, the
+  `trend_micro_computer` entitiy is classified as both 'Host' and 'Device'.
+
 ## 2.2.4 - 2022-11-23
 
 ### Changed

--- a/src/steps/fetch-computers/__tests__/index.test.ts
+++ b/src/steps/fetch-computers/__tests__/index.test.ts
@@ -96,7 +96,7 @@ test('computer entity conversion', () => {
   expect(createComputerEntity(computer)).toEqual({
     _key: 'trend-micro-computer:1',
     _type: 'trend_micro_computer',
-    _class: ['Host'],
+    _class: ['Host', 'Device'],
     name: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     displayName: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
     hostname: 'ec2-54-187-35-33.us-west-2.compute.amazonaws.com',
@@ -113,6 +113,11 @@ test('computer entity conversion', () => {
     createdOn: undefined,
     ec2InstanceId: undefined,
     hostGUID: '6BE38408-DA9E-4A03-1EB4-5CE824AD0C58',
+    category: 'endpoint',
+    make: null,
+    model: null,
+    serial: null,
+    deviceId: '6BE38408-DA9E-4A03-1EB4-5CE824AD0C58',
     _rawData: [
       {
         name: 'default',

--- a/src/steps/fetch-computers/index.ts
+++ b/src/steps/fetch-computers/index.ts
@@ -41,7 +41,7 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
       assign: {
         _key: id,
         _type: COMPUTER_TYPE,
-        _class: 'Host',
+        _class: ['Host', 'Device'],
 
         // normalize property names to match data model
         id,
@@ -57,6 +57,11 @@ export function createComputerEntity(computer: DeepSecurityComputer): Entity {
         applianceStatus: computer.computerStatus?.applianceStatus,
         agentGUID: computer.agentGUID,
         hostGUID: computer.hostGUID,
+        category: 'endpoint',
+        make: null,
+        model: null,
+        serial: null,
+        deviceId: computer.hostGUID,
       },
     },
   });


### PR DESCRIPTION
- Assigned 'Device' class to the `trend_micro_computer` entity. As of now, the
  `trend_micro_computer` entity is classified as both 'Host' and 'Device'.